### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <b>RawJSONBuilder</b>
 </h1>
 <p align="center">
-  📦 Minecraft <a href="https://minecraft.gamepedia.com/Raw_JSON_text_format">Raw JSON text</a> builder.
+  📦 Minecraft <a href="https://minecraft.wiki/w/Raw_JSON_text_format">Raw JSON text</a> builder.
   <br>
   <br>
   <a href="https://npmjs.com/package/rawjsonbuilder">

--- a/docs/index.html
+++ b/docs/index.html
@@ -2833,7 +2833,7 @@ img {
 				<b>RawJSONBuilder</b>
 			</h1>
 			<p align="center">
-				📦 Minecraft <a href="https://minecraft.gamepedia.com/Raw_JSON_text_format">Raw JSON text</a> builder.
+				📦 Minecraft <a href="https://minecraft.wiki/w/Raw_JSON_text_format">Raw JSON text</a> builder.
 				<br>
 				<br>
 				<a href="https://npmjs.com/package/rawjsonbuilder">

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -2833,7 +2833,7 @@ img {
 				<b>RawJSONBuilder</b>
 			</h1>
 			<p align="center">
-				📦 Minecraft <a href="https://minecraft.gamepedia.com/Raw_JSON_text_format">Raw JSON text</a> builder.
+				📦 Minecraft <a href="https://minecraft.wiki/w/Raw_JSON_text_format">Raw JSON text</a> builder.
 				<br>
 				<br>
 				<a href="https://npmjs.com/package/rawjsonbuilder">

--- a/src/components/Base.ts
+++ b/src/components/Base.ts
@@ -169,7 +169,7 @@ export class BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
      */
     setColor(color?: BaseComponent["color"]): this {
         this.color = color;
@@ -184,7 +184,7 @@ export class BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
      */
     setFont(font?: BaseComponent["font"]): this {
         this.font = font;
@@ -199,7 +199,7 @@ export class BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
      */
     setBold(bold: BaseComponent["bold"] = true): this {
         this.bold = bold;
@@ -214,7 +214,7 @@ export class BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
      */
     setItalic(italic: BaseComponent["italic"] = true): this {
         this.italic = italic;
@@ -229,7 +229,7 @@ export class BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
      */
     setUnderlined(underlined: BaseComponent["underlined"] = true): this {
         this.underlined = underlined;
@@ -244,7 +244,7 @@ export class BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
      */
     setStrikethrough(strikethrough: BaseComponent["strikethrough"] = true): this {
         this.strikethrough = strikethrough;
@@ -259,7 +259,7 @@ export class BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
      */
     setObfuscated(obfuscated: BaseComponent["obfuscated"] = true): this {
         this.obfuscated = obfuscated;
@@ -274,7 +274,7 @@ export class BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
      */
     setInsertion(insertion: BaseComponent["insertion"]): this {
         this.insertion = insertion;
@@ -289,7 +289,7 @@ export class BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
      */
     setClickEvent(event?: BaseComponent["clickEvent"]): this {
         this.clickEvent = event;
@@ -304,7 +304,7 @@ export class BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
      */
     setHoverEvent(event?: BaseComponent["hoverEvent"]): this {
         this.hoverEvent = event;
@@ -400,7 +400,7 @@ export class BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Java_Edition | Raw JSON text format}
      */
     addExtra(extra: Exclude<BaseComponent["extra"], undefined> | Exclude<BaseComponent["extra"], undefined>[number]): this {
         if (!this.extra) {

--- a/src/components/Keybind.ts
+++ b/src/components/Keybind.ts
@@ -19,7 +19,7 @@ export class KeybindComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Keybind | Keybind}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Keybind | Keybind}
      */
     setKeybind(keybind: KeybindComponent["keybind"] = ""): this {
         this.keybind = keybind;
@@ -35,7 +35,7 @@ export class KeybindComponent extends BaseComponent {
  *
  * @return KeybindComponent
  *
- * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Keybind | Keybind}
+ * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Keybind | Keybind}
  */
 export function keybind(keybind: KeybindComponent["keybind"]): KeybindComponent {
     return new KeybindComponent({

--- a/src/components/NBT.ts
+++ b/src/components/NBT.ts
@@ -27,7 +27,7 @@ export class NBTComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#NBT_Values | NBT Values}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#NBT_Values | NBT Values}
      */
     setNBT(nbt: NBTComponent["nbt"] = ""): this {
         this.nbt = nbt;
@@ -42,7 +42,7 @@ export class NBTComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#NBT_Values | NBT Values}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#NBT_Values | NBT Values}
      */
     setInterpret(interpret: NBTComponent["interpret"] = true): this {
         this.interpret = interpret;
@@ -57,7 +57,7 @@ export class NBTComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#NBT_Values | NBT Values}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#NBT_Values | NBT Values}
      */
     setBlock(block?: NBTComponent["block"]): this {
         this.block = block;
@@ -72,7 +72,7 @@ export class NBTComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#NBT_Values | NBT Values}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#NBT_Values | NBT Values}
      */
     setEntity(entity?: NBTComponent["entity"]): this {
         this.entity = entity;
@@ -87,7 +87,7 @@ export class NBTComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#NBT_Values | NBT Values}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#NBT_Values | NBT Values}
      */
     setStorage(storage?: NBTComponent["storage"]): this {
         this.storage = storage;
@@ -102,7 +102,7 @@ export class NBTComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#NBT_Values | NBT Values}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#NBT_Values | NBT Values}
      */
     setSeparator(separator?: NBTComponent["separator"]): this {
         this.separator = separator;
@@ -164,7 +164,7 @@ export class NBTComponent extends BaseComponent {
  *
  * @return NBTComponent
  *
- * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#NBT_Values | NBT Values}
+ * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#NBT_Values | NBT Values}
  */
 export function nbt(nbt: NBTComponent["nbt"], interpret?: NBTComponent["interpret"]): NBTComponent {
     return new NBTComponent({

--- a/src/components/Score.ts
+++ b/src/components/Score.ts
@@ -28,7 +28,7 @@ export class ScoreComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Scoreboard_Value | Scoreboard Value}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Scoreboard_Value | Scoreboard Value}
      */
     setName(name: IScore["name"] = ""): this {
         this.score.name = name;
@@ -43,7 +43,7 @@ export class ScoreComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Scoreboard_Value | Scoreboard Value}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Scoreboard_Value | Scoreboard Value}
      */
     setObjective(objective: IScore["objective"] = ""): this {
         this.score.objective = objective;
@@ -58,7 +58,7 @@ export class ScoreComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Scoreboard_Value | Scoreboard Value}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Scoreboard_Value | Scoreboard Value}
      */
     setValue(value?: IScore["value"]): this {
         this.score.value = value;
@@ -103,7 +103,7 @@ export class ScoreComponent extends BaseComponent {
  *
  * @return ScoreComponent
  *
- * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Scoreboard_Value | Scoreboard Value}
+ * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Scoreboard_Value | Scoreboard Value}
  */
 export function score(name: IScore["name"], objective: IScore["objective"], value?: IScore["value"]): ScoreComponent {
     return new ScoreComponent({

--- a/src/components/Selector.ts
+++ b/src/components/Selector.ts
@@ -22,7 +22,7 @@ export class SelectorComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Entity_Names | Entity Names}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Entity_Names | Entity Names}
      */
     setSelector(selector: SelectorComponent["selector"] = ""): this {
         this.selector = selector;
@@ -37,7 +37,7 @@ export class SelectorComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Entity_Names | Entity Names}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Entity_Names | Entity Names}
      */
     setSeparator(separator?: SelectorComponent["separator"]): this {
         this.separator = separator;
@@ -71,7 +71,7 @@ export class SelectorComponent extends BaseComponent {
  *
  * @return SelectorComponent
  *
- * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Entity_Names | Entity Names}
+ * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Entity_Names | Entity Names}
  */
 export function selector(selector: SelectorComponent["selector"]): SelectorComponent {
     return new SelectorComponent({

--- a/src/components/Text.ts
+++ b/src/components/Text.ts
@@ -19,7 +19,7 @@ export class TextComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Translated_Text | Plain Text}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Translated_Text | Plain Text}
      */
     setText(text: TextComponent["text"]): this {
         this.text = text;
@@ -36,7 +36,7 @@ export class TextComponent extends BaseComponent {
  *
  * @return TextComponent
  *
- * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Plain_Text | Plain Text}
+ * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Plain_Text | Plain Text}
  */
 export function text(text: TextComponent["text"], color?: BaseComponent["color"]): TextComponent {
     return new TextComponent({

--- a/src/components/Translate.ts
+++ b/src/components/Translate.ts
@@ -25,7 +25,7 @@ export class TranslateComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Translated_Text | Translated Text}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Translated_Text | Translated Text}
      */
     setTranslate(translate: TranslateComponent["translate"] = ""): this {
         this.translate = translate;
@@ -40,7 +40,7 @@ export class TranslateComponent extends BaseComponent {
      *
      * @return Current component context
      *
-     * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Translated_Text | Translated Text}
+     * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Translated_Text | Translated Text}
      */
     addWith(withTranslate: TranslateComponent["with"] | TranslateComponent["with"][number]): this {
         this.with = this.with.concat(withTranslate);
@@ -68,7 +68,7 @@ export class TranslateComponent extends BaseComponent {
  *
  * @return TranslateComponent
  *
- * @see {@link https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Translated_Text | Translated Text}
+ * @see {@link https://minecraft.wiki/w/Raw_JSON_text_format#Translated_Text | Translated Text}
  */
 export function translate(translate: TranslateComponent["translate"], withTranslate?: TranslateComponent["with"]): TranslateComponent {
     const component = new TranslateComponent({


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki

I skipped the files in `docs`, assuming those are generated.